### PR TITLE
Update getting started page and organize quickstarts 

### DIFF
--- a/docs/current_docs/ci/adopting.mdx
+++ b/docs/current_docs/ci/adopting.mdx
@@ -4,7 +4,7 @@ slug: /ci/adopting
 
 # Dagger for CI: Day 2
 
-Once you have [completed the quickstart](../getting-started/quickstart.mdx), and learned the basic concepts, it's time to take the next step: adopting Dagger in your project. We call this *daggerizing*. But how does one daggerize a project, exactly?
+Once you have [completed the quickstart](../getting-started/ci.mdx), and learned the basic concepts, it's time to take the next step: adopting Dagger in your project. We call this *daggerizing*. But how does one daggerize a project, exactly?
 
 Every project is different, and every pipeline is a unique snowflake (usually that's not a good thing). So we can't give you an exact step-by-step guide of how to daggerize your project. But we can share the collective experience of the Dagger community, distilled into a simple framework.
 
@@ -72,7 +72,7 @@ When choosing the language to use for your pipeline, follow these principles:
 
 ### Implementing
 
-If you haven't already, make sure to [complete the Quickstart](../getting-started/quickstart.mdx), which will teach you how to daggerize an example pipeline.
+If you haven't already, make sure to [complete the Quickstart](../getting-started/ci.mdx), which will teach you how to daggerize an example pipeline.
 
 Additionally, you can use the following resources:
 

--- a/docs/current_docs/getting-started/agent/index.mdx
+++ b/docs/current_docs/getting-started/agent/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Build an AI Agent"
-slug: /getting-started/agent
+slug: /getting-started/quickstarts/agent
 description: "Learn how to build an AI agent that can interact with Dagger workflows to automate tasks and add features."
 ---
 

--- a/docs/current_docs/getting-started/agent/inproject.mdx
+++ b/docs/current_docs/getting-started/agent/inproject.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Add an AI agent to an Existing Project"
-slug: /getting-started/agent-in-project
+slug: /getting-started/quickstarts/agent-in-project
 description: "Learn how to build an AI agent that can interact with an existing Daggerized project to add features and automate tasks."
 ---
 
@@ -24,11 +24,11 @@ Before beginning, ensure that:
 - you have configured an LLM provider to use with Dagger.
 - you have a GitHub account
 - you have completed the [AI agent quickstart](./index.mdx) to learn the basics of LLMs in Dagger.
-- you have completed the [CI quickstart](../quickstart.mdx) to a Daggerize a project.
+- you have completed the [CI quickstart](../ci.mdx) to a Daggerize a project.
 
 ## Inspect the example application
 
-This quickstart uses the [Daggerized project from the CI quickstart](../quickstart.mdx). To verify that your project is in the correct state, change to the project's working directory and list the available Dagger Functions:
+This quickstart uses the [Daggerized project from the CI quickstart](../ci.mdx). To verify that your project is in the correct state, change to the project's working directory and list the available Dagger Functions:
 
 ```shell
 cd hello-dagger

--- a/docs/current_docs/getting-started/ci.mdx
+++ b/docs/current_docs/getting-started/ci.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Quickstart"
-slug: "/getting-started/quickstart"
+title: "Build a CI Workflow"
+slug: "/getting-started/quickstarts/ci"
 description: "Build a CI workflow with Dagger"
 keywords: ["quickstart", "ci", "dagger", "workflow", "hello-dagger"]
 ---
@@ -8,7 +8,7 @@ keywords: ["quickstart", "ci", "dagger", "workflow", "hello-dagger"]
 import PartialIde from '@partials/_ide.mdx';
 import VideoPlayer from '@components/VideoPlayer';
 
-# Build a Workflow
+# Build a CI Workflow
 
 CI workflows often start simple, but eventually transform into a labyrinth of artisanal shell scripts and/or unmanageable YAML code. Dagger lets you replace those artisanal scripts and YAML with a modern API and cross-language scripting engine.
 

--- a/docs/current_docs/getting-started/core-concepts.mdx
+++ b/docs/current_docs/getting-started/core-concepts.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Core Concepts"
-slug: /getting-started/core-concepts
+slug: /getting-started/quickstarts/core-concepts
 description: "Learn about Dagger's core concepts, including containers, functions, and modules"
 ---
 
@@ -678,7 +678,7 @@ Once configured, every time you execute a Dagger workflow, its operational telem
 
 Now that you know the basics of Dagger, continue your journey with the resources below:
 
-- [Build a CI workflow](./quickstart.mdx)
+- [Build a CI workflow](./ci.mdx)
 - [Build an AI Agent](./agent/index.mdx)
 - [Learn about the Dagger API](../extending/index.mdx)
 - [Learn about Dagger Shell](../features/shell.mdx)

--- a/docs/current_docs/getting-started/index.mdx
+++ b/docs/current_docs/getting-started/index.mdx
@@ -7,7 +7,7 @@ description: "Learn how to get started with Dagger"
 
 Dagger is a powerful tool for building and managing application delivery workflows. This guide will help you get started with Dagger, covering the basics of how to set up your environment, create Dagger Modules, and run your first workflows.
 
-The getting started guide is divided into several sections to help you learn Dagger 
+The getting started guide is divided into several sections to help you learn Dagger
 
 ## Learn the basics
 
@@ -15,7 +15,7 @@ You can visit the core concepts to understand the fundamental building blocks of
 
 ## Quickstart
 
-If you prefer a hands-on approach, you can follow the [Quickstart guide](./quickstart.mdx) to quickly set up Dagger and run your first workflow.
+If you prefer a hands-on approach, you can follow the [Quickstart guide](./ci.mdx) to quickly set up Dagger and run your first workflow.
 
 ## Build AI Agents
 

--- a/docs/current_docs/getting-started/index.mdx
+++ b/docs/current_docs/getting-started/index.mdx
@@ -9,18 +9,18 @@ Dagger is a powerful tool for building and managing application delivery workflo
 
 The getting started guide is divided into several sections to help you learn Dagger
 
-## Learn the basics
+## Learn core concepts
 
-You can visit the core concepts to understand the fundamental building blocks of Dagger:
+Use the [core concepts quickstart](./core-concepts.mdx) to understand the fundamental building blocks of Dagger:
 
-## Quickstart
+## Build a CI workflow
 
-If you prefer a hands-on approach, you can follow the [Quickstart guide](./ci.mdx) to quickly set up Dagger and run your first workflow.
+Follow the [CI quickstart](./ci.mdx) to create your first CI workflow.
 
-## Build AI Agents
+## Build an AI agent
 
-If you're interested in using AI agents with Dagger, check out the [AI Agents guide](./agent/index.mdx) to learn how to integrate AI into your workflows using secure sandboxed environments and easily switch between different AI models with no code changes.
+Follow the [AI agent quickstart](./agent/index.mdx) to build AI agents that operate in secure sandboxed environments and work with different AI models with no code changes.
 
-## Add AI Agents to your existing workflows
+## Add an AI agent to your existing workflows
 
-If you have an existing CI/CD workflow powered by Dagger, you can follow this guide to [add AI agents](./agent/inproject.mdx) to your workflow. This guide will help you leverage the power of AI agents in your existing CI/CD pipelines.
+Follow the [AI agent integration quickstart](./agent/inproject.mdx) to add AI agents in your existing CI workflows.

--- a/docs/current_docs/getting-started/index.mdx
+++ b/docs/current_docs/getting-started/index.mdx
@@ -9,9 +9,13 @@ Dagger is a powerful tool for building and managing application delivery workflo
 
 The getting started guide is divided into several sections to help you learn Dagger
 
+## Installation
+
+Follow the [installation guide](./installation.mdx) for detailed instructions on how to install, uninstall and update Dagger.
+
 ## Learn core concepts
 
-Use the [core concepts quickstart](./core-concepts.mdx) to understand the fundamental building blocks of Dagger:
+Use the [core concepts quickstart](./core-concepts.mdx) to understand the fundamental building blocks of Dagger.
 
 ## Build a CI workflow
 

--- a/docs/current_docs/index.mdx
+++ b/docs/current_docs/index.mdx
@@ -26,9 +26,9 @@ With Dagger, you:
 
 ## Get started
 
-- [**Quickstart**](./getting-started/quickstart.mdx) - Learn Dagger fundamentals and build your first workflow
 - [**Installation**](./getting-started/installation.mdx) - Install Dagger and set up your development environment
 - [**Core Concepts**](./getting-started/core-concepts.mdx) - Understand typed objects, functions, and modules
+- [**CI Quickstart**](./getting-started/ci.mdx) - Learn Dagger fundamentals and build your first workflow
 
 ## Dagger Platform
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -33,8 +33,17 @@ module.exports = {
       items: [
         "getting-started/index",
         "getting-started/installation",
-        "getting-started/core-concepts",
-        "getting-started/quickstart",
+        {
+          type: "category",
+          label: "Quickstarts",
+          items: [
+            "getting-started/core-concepts",
+            "getting-started/ci",
+            "getting-started/agent/index",
+            "getting-started/agent/inproject",
+          ]
+        }
+
       ],
     },
     {


### PR DESCRIPTION
- Create a sub-node to organize all quickstarts together
- Fix missing left nav in agent quickstart pages
- Rename quickstart to CI quickstart
- Update getting started page content
- Fix links

WDYT of changing `Core Concepts` to `Basics` instead? @jasonmccallister 