### PR TITLE
Remove API overview reference page

### DIFF
--- a/docs/current_docs/reference/api/index.mdx
+++ b/docs/current_docs/reference/api/index.mdx
@@ -1,9 +1,0 @@
----
-title: "Overview"
-description: Learn how to use the Dagger API to create workflows, call functions, and extend the API with custom functions and modules.
----
-
-# Dagger API
-
-The Dagger API is an unified interface for composing Dagger workflows. It provides a set of core functions and core types for creating and managing application delivery workflows, including types for containers, files, directories, network services, secrets, and more. You can call these functions from `dagger`, the Dagger CLI, or from custom functions written in any supported programming language.
-

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -177,7 +177,6 @@ module.exports = {
       type: "category",
       label: "API and SDKs Documentation",
       items: [
-        "reference/api/index",
         "reference/api/internals",
         {
           type: "link",


### PR DESCRIPTION
This page doesn't add much, we can remove it IMHO